### PR TITLE
129 provide the backend config in accordance to the qiskit model

### DIFF
--- a/src/sqooler/schemes.py
+++ b/src/sqooler/schemes.py
@@ -4,6 +4,7 @@ There is no obvious need, why this code should be touch in a new back-end.
 """
 
 from collections.abc import Callable
+from typing import Optional
 from pydantic import ValidationError, BaseModel
 
 from typing_extensions import NotRequired, TypedDict
@@ -77,6 +78,37 @@ class BackendStatusSchemaOut(BaseModel):
     operational: bool
     pending_jobs: int
     status_msg: str
+
+
+class BackendConfigSchemaOut(BaseModel):
+    """
+    The schema send out to detail the configuration of the backend. We follow the
+    conventions of the qiskit configuration dictionary here.
+
+    Will becomes compatible with qiskit.providers.models.BackendConfiguration
+    """
+
+    display_name: str
+    conditional: bool = False
+    coupling_map: str = "linear"
+    dynamic_reprate_enabled: bool = False
+    local: bool = False
+    memory: bool = True
+    open_pulse: bool = False
+    backend_version: str
+    n_qubits: int
+    backend_name: str
+    basis_gates: list[str]
+    description: str
+    cold_atom_type: str
+    max_experiments: int
+    max_shots: int
+    simulator: bool
+    wire_order: str
+    num_species: int
+    gates: list
+    supported_instructions: list
+    url: Optional[str] = None
 
 
 class GateInstruction(BaseModel):

--- a/src/sqooler/storage_providers.py
+++ b/src/sqooler/storage_providers.py
@@ -1594,8 +1594,9 @@ class LocalProviderExtended(StorageProvider):
         """
         result_json_dir = "results/" + display_name
         result_dict = self.get_file_content(storage_path=result_json_dir, job_id=job_id)
-        backend_config_dict = self.get_backend_dict(display_name)
-        result_dict["backend_name"] = backend_config_dict["backend_name"]
+
+        backend_config_info = self.get_backend_dict(display_name)
+        result_dict["backend_name"] = backend_config_info.backend_name
 
         typed_result = cast(ResultDict, result_dict)
         return typed_result

--- a/src/sqooler/storage_providers.py
+++ b/src/sqooler/storage_providers.py
@@ -1037,7 +1037,7 @@ class MongodbProviderExtended(StorageProvider):
         backend_config_dict = config_collection.find_one(document_to_find)
 
         if not backend_config_dict:
-            return {}
+            raise FileNotFoundError("The backend does not exist for the given storage.")
 
         backend_config_dict.pop("_id")
         qiskit_backend_dict = self.backend_dict_to_qiskit(backend_config_dict)
@@ -1462,7 +1462,7 @@ class LocalProviderExtended(StorageProvider):
         return backend_names
 
     @validate_active
-    def get_backend_dict(self, display_name: str) -> dict:
+    def get_backend_dict(self, display_name: str) -> BackendConfigSchemaOut:
         """
         The configuration dictionary of the backend such that it can be sent out to the API to
         the common user. We make sure that it is compatible with QISKIT within this function.
@@ -1472,6 +1472,9 @@ class LocalProviderExtended(StorageProvider):
 
         Returns:
             The full schema of the backend.
+
+        Raises:
+            FileNotFoundError: If the backend does not exist
         """
         # path of the configs
         config_path = self.base_path + "/backends/configs"
@@ -1481,7 +1484,7 @@ class LocalProviderExtended(StorageProvider):
             backend_config_dict = json.load(json_file)
 
         if not backend_config_dict:
-            return {}
+            raise FileNotFoundError("The backend does not exist for the given storage.")
 
         qiskit_backend_dict = self.backend_dict_to_qiskit(backend_config_dict)
         return qiskit_backend_dict

--- a/src/sqooler/storage_providers.py
+++ b/src/sqooler/storage_providers.py
@@ -30,6 +30,7 @@ from .schemes import (
     DropboxLoginInformation,
     LocalLoginInformation,
     BackendStatusSchemaOut,
+    BackendConfigSchemaOut,
 )
 
 
@@ -86,7 +87,7 @@ class StorageProvider(ABC):
         """
 
     @abstractmethod
-    def get_backend_dict(self, display_name: str) -> dict:
+    def get_backend_dict(self, display_name: str) -> BackendConfigSchemaOut:
         """
         The configuration of the backend.
 
@@ -262,7 +263,9 @@ class StorageProvider(ABC):
             the path towards the job
         """
 
-    def backend_dict_to_qiskit(self, backend_config_dict: dict) -> dict:
+    def backend_dict_to_qiskit(
+        self, backend_config_dict: dict
+    ) -> BackendConfigSchemaOut:
         """
         This function transforms the dictionary that is safed in the storage provider
         into a qiskit backend dictionnary.
@@ -295,7 +298,7 @@ class StorageProvider(ABC):
         backend_config_dict["open_pulse"] = False
         backend_config_dict["memory"] = True
         backend_config_dict["coupling_map"] = "linear"
-        return backend_config_dict
+        return BackendConfigSchemaOut(**backend_config_dict)
 
     def backend_dict_to_qiskit_status(
         self, backend_dict: dict
@@ -661,7 +664,7 @@ class DropboxProviderExtended(StorageProvider):
                 backend_names.append(entry.name)
         return backend_names
 
-    def get_backend_dict(self, display_name: str) -> dict:
+    def get_backend_dict(self, display_name: str) -> BackendConfigSchemaOut:
         """
         The configuration of the backend.
 
@@ -790,8 +793,8 @@ class DropboxProviderExtended(StorageProvider):
         result_dict = self.get_file_content(
             storage_path=result_json_dir, job_id=result_json_name
         )
-        backend_config_dict = self.get_backend_dict(display_name)
-        result_dict["backend_name"] = backend_config_dict["backend_name"]
+        backend_config_info = self.get_backend_dict(display_name)
+        result_dict["backend_name"] = backend_config_info.backend_name
 
         typed_result = cast(ResultDict, result_dict)
         return typed_result
@@ -1014,7 +1017,7 @@ class MongodbProviderExtended(StorageProvider):
         return backend_names
 
     @validate_active
-    def get_backend_dict(self, display_name: str) -> dict:
+    def get_backend_dict(self, display_name: str) -> BackendConfigSchemaOut:
         """
         The configuration dictionary of the backend such that it can be sent out to the API to
         the common user. We make sure that it is compatible with QISKIT within this function.
@@ -1189,8 +1192,8 @@ class MongodbProviderExtended(StorageProvider):
         """
         result_json_dir = "results/" + display_name
         result_dict = self.get_file_content(storage_path=result_json_dir, job_id=job_id)
-        backend_config_dict = self.get_backend_dict(display_name)
-        result_dict["backend_name"] = backend_config_dict["backend_name"]
+        backend_config_info = self.get_backend_dict(display_name)
+        result_dict["backend_name"] = backend_config_info.backend_name
 
         typed_result = cast(ResultDict, result_dict)
         return typed_result

--- a/tests/test_dropbox_provider_extended.py
+++ b/tests/test_dropbox_provider_extended.py
@@ -95,11 +95,17 @@ class TestDropboxProviderExtended:
         dummy_id = uuid.uuid4().hex[:5]
         dummy_dict: dict = {}
         dummy_dict["gates"] = []
+        dummy_dict["supported_instructions"] = []
         dummy_dict["name"] = "Dummy"
         dummy_dict["num_wires"] = 3
         dummy_dict["version"] = "0.0.1"
         dummy_dict["simulator"] = True
-
+        dummy_dict["cold_atom_type"] = "fermion"
+        dummy_dict["num_species"] = 1
+        dummy_dict["wire_order"] = "interleaved"
+        dummy_dict["max_shots"] = 5
+        dummy_dict["max_experiments"] = 5
+        dummy_dict["description"] = "Dummy simulator for testing"
         backend_name = f"dummy{dummy_id}"
         dummy_dict["display_name"] = backend_name
         dummy_path = f"Backend_files/Config/{backend_name}"
@@ -110,7 +116,8 @@ class TestDropboxProviderExtended:
         assert f"dummy{dummy_id}" in backends
 
         # can we get the config of the backend ?
-        backend_dict = storage_provider.get_backend_dict(backend_name)
+        backend_info = storage_provider.get_backend_dict(backend_name)
+        backend_dict = backend_info.model_dump()
         assert (
             backend_dict["backend_name"]
             == f"dropboxtest_{dummy_dict['display_name']}_simulator"
@@ -130,13 +137,20 @@ class TestDropboxProviderExtended:
         dummy_id = uuid.uuid4().hex[:5]
         dummy_dict: dict = {}
         dummy_dict["gates"] = []
+        dummy_dict["supported_instructions"] = []
         dummy_dict["name"] = "Dummy"
         dummy_dict["num_wires"] = 3
         dummy_dict["version"] = "0.0.1"
         dummy_dict["simulator"] = True
-
+        dummy_dict["cold_atom_type"] = "fermion"
+        dummy_dict["num_species"] = 1
+        dummy_dict["wire_order"] = "interleaved"
+        dummy_dict["max_shots"] = 5
+        dummy_dict["max_experiments"] = 5
+        dummy_dict["description"] = "Dummy simulator for testing"
         backend_name = f"dummy{dummy_id}"
         dummy_dict["display_name"] = backend_name
+
         dummy_path = f"Backend_files/Config/{backend_name}"
         storage_provider.upload(dummy_dict, dummy_path, job_id="config")
 

--- a/tests/test_local_provider_extended.py
+++ b/tests/test_local_provider_extended.py
@@ -140,7 +140,9 @@ class TestLocalProviderExtended:
             backend_dict["backend_name"]
             == f"localtest_{dummy_dict['display_name']}_simulator"
         )
-
+        # make sure that we raise an error if we try to get a backend that does not exist
+        with pytest.raises(FileNotFoundError):
+            storage_provider.get_backend_dict("dummy_non_existing")
         storage_provider.delete_file(config_path, backend_name)
 
     def test_status(self) -> None:

--- a/tests/test_local_provider_extended.py
+++ b/tests/test_local_provider_extended.py
@@ -112,13 +112,19 @@ class TestLocalProviderExtended:
         dummy_id = uuid.uuid4().hex[:5]
         dummy_dict: dict = {}
         dummy_dict["gates"] = []
+        dummy_dict["supported_instructions"] = []
         dummy_dict["name"] = "Dummy"
         dummy_dict["num_wires"] = 3
         dummy_dict["version"] = "0.0.1"
-
+        dummy_dict["simulator"] = True
+        dummy_dict["cold_atom_type"] = "fermion"
+        dummy_dict["num_species"] = 1
+        dummy_dict["wire_order"] = "interleaved"
+        dummy_dict["max_shots"] = 5
+        dummy_dict["max_experiments"] = 5
+        dummy_dict["description"] = "Dummy simulator for testing"
         backend_name = f"dummy{dummy_id}"
         dummy_dict["display_name"] = backend_name
-        dummy_dict["simulator"] = True
 
         config_path = "backends/configs"
         storage_provider.upload(dummy_dict, config_path, job_id=backend_name)
@@ -128,7 +134,8 @@ class TestLocalProviderExtended:
         assert f"dummy{dummy_id}" in backends
 
         # can we get the config of the backend ?
-        backend_dict = storage_provider.get_backend_dict(backend_name)
+        backend_info = storage_provider.get_backend_dict(backend_name)
+        backend_dict = backend_info.model_dump()
         assert (
             backend_dict["backend_name"]
             == f"localtest_{dummy_dict['display_name']}_simulator"
@@ -241,9 +248,16 @@ class TestLocalProviderExtended:
         dummy_id = uuid.uuid4().hex[:5]
         dummy_dict: dict = {}
         dummy_dict["gates"] = []
+        dummy_dict["supported_instructions"] = []
         dummy_dict["name"] = "Dummy"
         dummy_dict["num_wires"] = 3
         dummy_dict["version"] = "0.0.1"
+        dummy_dict["cold_atom_type"] = "fermion"
+        dummy_dict["num_species"] = 1
+        dummy_dict["wire_order"] = "interleaved"
+        dummy_dict["max_shots"] = 5
+        dummy_dict["max_experiments"] = 5
+        dummy_dict["description"] = "Dummy simulator for testing"
 
         backend_name = f"dummy{dummy_id}"
         dummy_dict["display_name"] = backend_name

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -152,10 +152,18 @@ class TestMongodbProviderExtended:
         dummy_id = uuid.uuid4().hex[:5]
         dummy_dict: dict = {}
         dummy_dict["gates"] = []
+        dummy_dict["supported_instructions"] = []
         dummy_dict["name"] = "Dummy"
         dummy_dict["num_wires"] = 3
         dummy_dict["version"] = "0.0.1"
         dummy_dict["simulator"] = True
+        dummy_dict["cold_atom_type"] = "fermion"
+        dummy_dict["num_species"] = 1
+        dummy_dict["wire_order"] = "interleaved"
+        dummy_dict["max_shots"] = 5
+        dummy_dict["max_experiments"] = 5
+        dummy_dict["description"] = "Dummy simulator for testing"
+
         backend_name = f"dummy{dummy_id}"
         dummy_dict["display_name"] = backend_name
 
@@ -168,7 +176,8 @@ class TestMongodbProviderExtended:
         assert f"dummy{dummy_id}" in backends
 
         # can we get the config of the backend ?
-        backend_dict = storage_provider.get_backend_dict(backend_name)
+        backend_info = storage_provider.get_backend_dict(backend_name)
+        backend_dict = backend_info.model_dump()
         assert (
             backend_dict["backend_name"]
             == f"mongodbtest_{dummy_dict['display_name']}_simulator"
@@ -234,9 +243,16 @@ class TestMongodbProviderExtended:
         dummy_id = uuid.uuid4().hex[:5]
         dummy_dict: dict = {}
         dummy_dict["gates"] = []
+        dummy_dict["supported_instructions"] = []
         dummy_dict["name"] = "Dummy"
         dummy_dict["num_wires"] = 3
         dummy_dict["version"] = "0.0.1"
+        dummy_dict["cold_atom_type"] = "fermion"
+        dummy_dict["num_species"] = 1
+        dummy_dict["wire_order"] = "interleaved"
+        dummy_dict["max_shots"] = 5
+        dummy_dict["max_experiments"] = 5
+        dummy_dict["description"] = "Dummy simulator for testing"
 
         backend_name = f"dummy{dummy_id}"
         dummy_dict["display_name"] = backend_name

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -182,6 +182,9 @@ class TestMongodbProviderExtended:
             backend_dict["backend_name"]
             == f"mongodbtest_{dummy_dict['display_name']}_simulator"
         )
+        # make sure that we raise an error if we try to get a backend that does not exist
+        with pytest.raises(FileNotFoundError):
+            storage_provider.get_backend_dict("dummy_non_existing")
 
         storage_provider.delete_file(config_path, mongo_id)
 


### PR DESCRIPTION
This should enforce much stronger typing for the configs.