### PR TITLE
Fail safely the `get_result`

### DIFF
--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -177,7 +177,8 @@ class StorageProvider(ABC):
             job_id: The job_id of the job that we want to upload the status for
 
         Returns:
-            The result dict of the job
+            The result dict of the job. If the information is not available, the result dict
+            has a status of "ERROR".
         """
 
     @abstractmethod

--- a/src/sqooler/storage_providers/dropbox.py
+++ b/src/sqooler/storage_providers/dropbox.py
@@ -505,9 +505,21 @@ class DropboxProviderExtended(StorageProvider):
         """
         result_json_dir = "Backend_files/Result/" + display_name + "/" + username
         result_json_name = "result-" + job_id
-        result_dict = self.get_file_content(
-            storage_path=result_json_dir, job_id=result_json_name
-        )
+        try:
+            result_dict = self.get_file_content(
+                storage_path=result_json_dir, job_id=result_json_name
+            )
+        except FileNotFoundError:
+            return ResultDict(
+                display_name=display_name,
+                backend_version="",
+                job_id=job_id,
+                qobj_id=None,
+                success=False,
+                status="ERROR",
+                header={},
+                results=[],
+            )
         backend_config_info = self.get_backend_dict(display_name)
         result_dict["backend_name"] = backend_config_info.backend_name
 

--- a/src/sqooler/storage_providers/dropbox.py
+++ b/src/sqooler/storage_providers/dropbox.py
@@ -501,7 +501,8 @@ class DropboxProviderExtended(StorageProvider):
             job_id: The job_id of the job that we want to upload the status for
 
         Returns:
-            The result dict of the job
+            The result dict of the job. If the information is not available, the result dict
+            has a status of "ERROR".
         """
         result_json_dir = "Backend_files/Result/" + display_name + "/" + username
         result_json_name = "result-" + job_id

--- a/src/sqooler/storage_providers/local.py
+++ b/src/sqooler/storage_providers/local.py
@@ -347,8 +347,22 @@ class LocalProviderExtended(StorageProvider):
             The result dict of the job
         """
         result_json_dir = "results/" + display_name
-        result_dict = self.get_file_content(storage_path=result_json_dir, job_id=job_id)
-
+        try:
+            result_dict = self.get_file_content(
+                storage_path=result_json_dir, job_id=job_id
+            )
+        except FileNotFoundError:
+            # if the job_id is not valid, we return an error
+            return ResultDict(
+                display_name=display_name,
+                backend_version="",
+                job_id=job_id,
+                qobj_id=None,
+                success=False,
+                status="ERROR",
+                header={},
+                results=[],
+            )
         backend_config_info = self.get_backend_dict(display_name)
         result_dict["backend_name"] = backend_config_info.backend_name
         typed_result = ResultDict(**result_dict)

--- a/src/sqooler/storage_providers/local.py
+++ b/src/sqooler/storage_providers/local.py
@@ -344,7 +344,8 @@ class LocalProviderExtended(StorageProvider):
             job_id: The job_id of the job that we want to upload the status for
 
         Returns:
-            The result dict of the job
+            The result dict of the job. If the information is not available, the result dict
+            has a status of "ERROR".
         """
         result_json_dir = "results/" + display_name
         try:

--- a/src/sqooler/storage_providers/mongodb.py
+++ b/src/sqooler/storage_providers/mongodb.py
@@ -422,14 +422,15 @@ class MongodbProviderExtended(StorageProvider):
             job_id: The job_id of the job that we want to upload the status for
 
         Returns:
-            The result dict of the job
+            The result dict of the job. If the information is not available, the result dict
+            has a status of "ERROR".
         """
         result_json_dir = "results/" + display_name
         try:
             result_dict = self.get_file_content(
                 storage_path=result_json_dir, job_id=job_id
             )
-        except FileNotFoundError as err:
+        except FileNotFoundError:
             # if the job_id is not valid, we return an error
             return ResultDict(
                 display_name=display_name,

--- a/src/sqooler/storage_providers/mongodb.py
+++ b/src/sqooler/storage_providers/mongodb.py
@@ -425,7 +425,22 @@ class MongodbProviderExtended(StorageProvider):
             The result dict of the job
         """
         result_json_dir = "results/" + display_name
-        result_dict = self.get_file_content(storage_path=result_json_dir, job_id=job_id)
+        try:
+            result_dict = self.get_file_content(
+                storage_path=result_json_dir, job_id=job_id
+            )
+        except FileNotFoundError as err:
+            # if the job_id is not valid, we return an error
+            return ResultDict(
+                display_name=display_name,
+                backend_version="",
+                job_id=job_id,
+                qobj_id=None,
+                success=False,
+                status="ERROR",
+                header={},
+                results=[],
+            )
         backend_config_info = self.get_backend_dict(display_name)
         result_dict["backend_name"] = backend_config_info.backend_name
 

--- a/tests/test_dropbox_provider_extended.py
+++ b/tests/test_dropbox_provider_extended.py
@@ -260,6 +260,14 @@ class TestDropboxProviderExtended:
         result_json_name = "result-" + job_id
 
         storage_provider.upload(dummy_result, result_json_dir, result_json_name)
+        # what happens if we try to get a result that does not exist ?
+        result_info = storage_provider.get_result(
+            display_name=backend_name,
+            username=username,
+            job_id="dglfjhous",
+        )
+        assert result_info.status == "ERROR"
+
         # now get the result
         result_info = storage_provider.get_result(
             display_name=backend_name,

--- a/tests/test_local_provider_extended.py
+++ b/tests/test_local_provider_extended.py
@@ -384,6 +384,13 @@ class TestLocalProviderExtended:
         }
         result_json_dir = "results/" + backend_name
         storage_provider.upload(dummy_result, result_json_dir, job_id)
+        # what happens if we try to get a result that does not exist ?
+        result_info = storage_provider.get_result(
+            display_name=backend_name,
+            username=username,
+            job_id="dglfjhous",
+        )
+        assert result_info.status == "ERROR"
 
         # now get the result
         result_info = storage_provider.get_result(

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -386,6 +386,14 @@ class TestMongodbProviderExtended:
         result_json_dir = "results/" + backend_name
         storage_provider.upload(dummy_result, result_json_dir, job_id)
 
+        # what happens if we try get an unknown job ?
+        job_result = storage_provider.get_result(
+            display_name=backend_name,
+            username=username,
+            job_id=uuid.uuid4().hex,
+        )
+        assert job_result.status == "ERROR"
+
         # now get the result
         result_info = storage_provider.get_result(
             display_name=backend_name,


### PR DESCRIPTION
Raises an error if the file does not exist