### PR TITLE
Do not allow to add a config with a name that already exists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ BASE_PATH = "storage"
 TEST_USERNAME = "test"
 
 # the base64 encoded private key for signing results
-PRIVATE_RESULT_KEY = "<YOUR_PRIVATE_KEY>"
+PRIVATE_JWK_STR = "<YOUR_PRIVATE_KEY>"
+
 
 # setting for test MongoDB 
 MONGODB_USERNAME = "<YOUR_MONGODB_USERNAME>"

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,3 +56,7 @@ Right now we have not yet implemented the verification of the results. This will
 
 - Alice has the full result JWS including header, payload and signature.
 - Alice has the appropiate public key the corresponds to the `kid` from the JWS header. She can now verify the signature. 
+
+## Signing the configuration
+
+It is now also possible to sign the backend configuration. This happens automatically if the `Spooler` object is configured to be signed. The `upload_config` and `update_config` will then sign the document before uploading it to the storage. This enables us now to have several backend providers in parallel without a central authority. Importantly, we can now hinder the collusion of two backends with the same name because you can only update the files if you are the owner of the private key.

--- a/docs/test_signing.ipynb
+++ b/docs/test_signing.ipynb
@@ -482,23 +482,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sqooler.security import create_jwk_pair"
+    "from sqooler.security import create_jwk_pair, jwk_from_config_str"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "eyJ4IjoiMEI0Q2E1bzR4WkxsbWhfT2xFR0RncVZwdXJQOW9nTGZxQk5nTmtZaVpNTT0iLCJrZXlfb3BzIjoic2lnbiIsImtpZCI6InRlc3Rfa2V5IiwiZCI6ImYweVd0T0RKem8yeWpKZTJTai0zWTR5UkRzSm1fRGx0dVlKbm1NUlMwaXM9Iiwia3R5IjoiT0tQIiwiYWxnIjoiRWREU0EiLCJjcnYiOiJFZDI1NTE5In0=\n"
+      "eyJ4IjoiZ2x2a3hLeVQxblJlTmFXV2hzYnJtNFpoZUp3alliWnJBZUlIcEFIbno3RT0iLCJrZXlfb3BzIjoic2lnbiIsImtpZCI6InRlc3Rfa2V5IiwiZCI6IkVKajVPeVQ0dlhtaDVJOUt2QkVUN1U0bHdDXzd4VDdUeTdoREZrajBRbW89Iiwia3R5IjoiT0tQIiwiYWxnIjoiRWREU0EiLCJjcnYiOiJFZDI1NTE5In0=\n"
      ]
     }
    ],
@@ -507,6 +507,54 @@
     "\n",
     "private_key_str = private_jwk.to_config_str()\n",
     "print(private_key_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "JWK(x=b'glvkxKyT1nReNaWWhsbrm4ZheJwjYbZrAeIHpAHnz7E=', key_ops='sign', kid='test_key', d=b'EJj5OyT4vXmh5I9KvBET7U4lwC_7xT7Ty7hDFkj0Qmo=', kty='OKP', alg='EdDSA', crv='Ed25519')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jwk_from_config_str(private_key_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What about the serialization of the datetime ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel\n",
+    "from datetime import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TestModel(BaseModel):\n",
+    "    name: str\n",
+    "    last_queued: datetime"
    ]
   }
  ],

--- a/src/sqooler/security.py
+++ b/src/sqooler/security.py
@@ -48,18 +48,18 @@ class JWSHeader(BaseModel):
         return base64_encoded
 
 
-def datetime_handler(input: Any) -> str:
+def datetime_handler(in_var: Any) -> str:
     """
     Convert a datetime object to a string.
 
     Args:
-        input : The object to convert
+        in_var : The object to convert
 
     Returns:
         str : The string representation of the object
     """
-    if isinstance(input, datetime.datetime):
-        return input.isoformat()
+    if isinstance(in_var, datetime.datetime):
+        return in_var.isoformat()
     raise TypeError("Unknown type")
 
 

--- a/src/sqooler/security.py
+++ b/src/sqooler/security.py
@@ -5,7 +5,9 @@ Any suggestions for improvements will be very welcome."""
 
 import json
 import base64
-from typing import Literal, Optional
+from typing import Literal, Optional, Any
+
+import datetime
 
 from pydantic import BaseModel, Field
 from cryptography.exceptions import InvalidSignature
@@ -46,6 +48,21 @@ class JWSHeader(BaseModel):
         return base64_encoded
 
 
+def datetime_handler(input: Any) -> str:
+    """
+    Convert a datetime object to a string.
+
+    Args:
+        input : The object to convert
+
+    Returns:
+        str : The string representation of the object
+    """
+    if isinstance(input, datetime.datetime):
+        return input.isoformat()
+    raise TypeError("Unknown type")
+
+
 def payload_to_base64url(payload: dict) -> bytes:
     """
     Convert an arbitrary payload to a base64url encoded string.
@@ -58,7 +75,7 @@ def payload_to_base64url(payload: dict) -> bytes:
     """
 
     # transform into a json string
-    payload_string = json.dumps(payload)
+    payload_string = json.dumps(payload, default=datetime_handler)
 
     # binary encode the json string
     binary_string = payload_string.encode()

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -368,7 +368,9 @@ class StorageProvider(ABC):
         """
 
     @abstractmethod
-    def get_next_job_in_queue(self, display_name: DisplayNameStr) -> NextJobSchema:
+    def get_next_job_in_queue(
+        self, display_name: DisplayNameStr, private_jwk: Optional[JWK]
+    ) -> NextJobSchema:
         """
         A function that obtains the next job in the queue. If there is no job, it returns an empty
         dict. If there is a job, it moves the job from the queue to the running folder.
@@ -376,6 +378,7 @@ class StorageProvider(ABC):
 
         Args:
             display_name: The name of the backend
+            private_jwk: The private JWK to sign the result with
 
         Returns:
             the job dict

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -460,6 +460,25 @@ class StorageProvider(ABC):
             upload_dict = config_dict.model_dump()
         return upload_dict
 
+    def _adapt_get_config(self, config_dict: dict) -> BackendConfigSchemaIn:
+        """
+        Adapt the config dict to the BackendConfigSchemaIn.
+
+        Args:
+            config_dict: The dictionary containing the configuration
+
+        Returns:
+            The adapted config dict
+        """
+        # we should verify the result before we send it out
+        expected_keys_for_jws = {"header", "payload", "signature"}
+        if set(config_dict.keys()) == expected_keys_for_jws:
+            payload = config_dict["payload"]
+            typed_config = BackendConfigSchemaIn(**payload)
+        else:
+            typed_config = BackendConfigSchemaIn(**config_dict)
+        return typed_config
+
     def _adapt_result_dict(
         self, result_dict: dict, backend_config_info: BackendConfigSchemaOut
     ) -> ResultDict:

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -262,6 +262,27 @@ class StorageProvider(ABC):
             config_dict: The model containing the configuration
             display_name : The name of the backend
 
+        Raises:
+            ValueError: If the configuration already exists
+
+        Returns:
+            None
+        """
+
+    @abstractmethod
+    def update_config(
+        self, config_dict: BackendConfigSchemaIn, display_name: DisplayNameStr
+    ) -> None:
+        """
+        The function that updates an existing spooler configuration for the storage.
+
+        Args:
+            config_dict: The model containing the configuration
+            display_name : The name of the backend
+
+        Raises:
+            FileNotFoundError: If the configuration does not exist
+
         Returns:
             None
         """
@@ -398,7 +419,7 @@ class StorageProvider(ABC):
         config_dict.last_queue_check = current_time
 
         # upload the new configuration
-        self.upload_config(config_dict, display_name)
+        self.update_config(config_dict, display_name)
 
     def backend_dict_to_qiskit(
         self, backend_config_info: BackendConfigSchemaIn

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -253,7 +253,10 @@ class StorageProvider(ABC):
 
     @abstractmethod
     def upload_config(
-        self, config_dict: BackendConfigSchemaIn, display_name: DisplayNameStr
+        self,
+        config_dict: BackendConfigSchemaIn,
+        display_name: DisplayNameStr,
+        private_jwk: Optional[JWK],
     ) -> None:
         """
         The function that uploads the spooler configuration to the storage.
@@ -261,6 +264,7 @@ class StorageProvider(ABC):
         Args:
             config_dict: The model containing the configuration
             display_name : The name of the backend
+            private_jwk: The private JWK to sign the result with
 
         Raises:
             ValueError: If the configuration already exists

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -271,7 +271,10 @@ class StorageProvider(ABC):
 
     @abstractmethod
     def update_config(
-        self, config_dict: BackendConfigSchemaIn, display_name: DisplayNameStr
+        self,
+        config_dict: BackendConfigSchemaIn,
+        display_name: DisplayNameStr,
+        private_jwk: Optional[JWK] = None,
     ) -> None:
         """
         The function that updates an existing spooler configuration for the storage.
@@ -279,6 +282,7 @@ class StorageProvider(ABC):
         Args:
             config_dict: The model containing the configuration
             display_name : The name of the backend
+            private_jwk: The private JWK to sign the result with
 
         Raises:
             FileNotFoundError: If the configuration does not exist
@@ -397,7 +401,9 @@ class StorageProvider(ABC):
             typed_result = ResultDict(**result_dict)
         return typed_result
 
-    def timestamp_queue(self, display_name: DisplayNameStr) -> None:
+    def timestamp_queue(
+        self, display_name: DisplayNameStr, private_jwk: Optional[JWK] = None
+    ) -> None:
         """
         Updates the time stamp for when the system last looked into the file queue.
         This allows us to track if the system is actually online or not.
@@ -419,7 +425,7 @@ class StorageProvider(ABC):
         config_dict.last_queue_check = current_time
 
         # upload the new configuration
-        self.update_config(config_dict, display_name)
+        self.update_config(config_dict, display_name, private_jwk)
 
     def backend_dict_to_qiskit(
         self, backend_config_info: BackendConfigSchemaIn

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -417,6 +417,7 @@ class StorageProvider(ABC):
 
         Args:
             display_name : The name of the backend
+            private_jwk: The private JWK to sign the result with
 
         Returns:
             None

--- a/src/sqooler/storage_providers/base.py
+++ b/src/sqooler/storage_providers/base.py
@@ -369,7 +369,7 @@ class StorageProvider(ABC):
 
     @abstractmethod
     def get_next_job_in_queue(
-        self, display_name: DisplayNameStr, private_jwk: Optional[JWK]
+        self, display_name: DisplayNameStr, private_jwk: Optional[JWK] = None
     ) -> NextJobSchema:
         """
         A function that obtains the next job in the queue. If there is no job, it returns an empty

--- a/src/sqooler/storage_providers/dropbox.py
+++ b/src/sqooler/storage_providers/dropbox.py
@@ -502,13 +502,7 @@ class DropboxProviderExtended(StorageProvider):
         backend_config_dict = self.get_file_content(
             storage_path=backend_json_path, job_id="config"
         )
-        # done day we should verify the result before we send it out
-        expected_keys_for_jws = {"header", "payload", "signature"}
-        if set(backend_config_dict.keys()) == expected_keys_for_jws:
-            payload = backend_config_dict["payload"]
-            typed_config = BackendConfigSchemaIn(**payload)
-        else:
-            typed_config = BackendConfigSchemaIn(**backend_config_dict)
+        typed_config = self._adapt_get_config(backend_config_dict)
         return typed_config
 
     def get_backend_status(

--- a/src/sqooler/storage_providers/local.py
+++ b/src/sqooler/storage_providers/local.py
@@ -363,6 +363,42 @@ class LocalProviderExtended(StorageProvider):
             )
         return self._adapt_result_dict(result_dict, backend_config_info)
 
+    def update_config(
+        self, config_dict: BackendConfigSchemaIn, display_name: DisplayNameStr
+    ) -> None:
+        """
+        The function that updates the spooler configuration on the storage.
+
+        Args:
+            config_dict: The dictionary containing the configuration
+            display_name : The name of the backend
+
+        Returns:
+            None
+        """
+        # path of the configs
+        config_path = os.path.join(self.base_path, "backends/configs")
+        config_path = os.path.normpath(config_path)
+        # test if the config path already exists. If it does not, create it
+        if not os.path.exists(config_path):
+            os.makedirs(config_path)
+
+        file_name = display_name + ".json"
+        full_json_path = os.path.join(config_path, file_name)
+        secure_path = os.path.normpath(full_json_path)
+
+        # check if the file already exists
+        if not os.path.exists(secure_path):
+            raise FileNotFoundError(
+                (
+                    f"The file {secure_path} does not exist and should not be updated."
+                    "Use the upload_config method instead."
+                )
+            )
+
+        with open(secure_path, "w", encoding="utf-8") as json_file:
+            json_file.write(config_dict.model_dump_json())
+
     def upload_config(
         self, config_dict: BackendConfigSchemaIn, display_name: DisplayNameStr
     ) -> None:
@@ -386,6 +422,13 @@ class LocalProviderExtended(StorageProvider):
         file_name = display_name + ".json"
         full_json_path = os.path.join(config_path, file_name)
         secure_path = os.path.normpath(full_json_path)
+
+        # check if the file already exists
+        if os.path.exists(secure_path):
+            raise FileExistsError(
+                f"The file {secure_path} already exists and should not be overwritten."
+            )
+
         with open(secure_path, "w", encoding="utf-8") as json_file:
             json_file.write(config_dict.model_dump_json())
 

--- a/src/sqooler/storage_providers/local.py
+++ b/src/sqooler/storage_providers/local.py
@@ -466,23 +466,9 @@ class LocalProviderExtended(StorageProvider):
             The configuration of the backend in complete form.
         """
         # path of the configs
-        config_path = self.base_path + "/backends/configs"
-        file_name = display_name + ".json"
-        full_json_path = os.path.join(config_path, file_name)
-        secure_path = os.path.normpath(full_json_path)
-        with open(secure_path, "r", encoding="utf-8") as json_file:
-            backend_config_dict = json.load(json_file)
-
-        if not backend_config_dict:
-            raise FileNotFoundError("The backend does not exist for the given storage.")
-
-        # done day we should verify the result before we send it out
-        expected_keys_for_jws = {"header", "payload", "signature"}
-        if set(backend_config_dict.keys()) == expected_keys_for_jws:
-            payload = backend_config_dict["payload"]
-            typed_config = BackendConfigSchemaIn(**payload)
-        else:
-            typed_config = BackendConfigSchemaIn(**backend_config_dict)
+        config_path = "/backends/configs"
+        backend_config_dict = self.get_file_content(config_path, job_id=display_name)
+        typed_config = self._adapt_get_config(backend_config_dict)
         return typed_config
 
     def upload_public_key(self, public_jwk: JWK, display_name: DisplayNameStr) -> None:

--- a/src/sqooler/storage_providers/mongodb.py
+++ b/src/sqooler/storage_providers/mongodb.py
@@ -9,7 +9,6 @@ from typing import Optional
 from pymongo.mongo_client import MongoClient
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
-from icecream import ic
 
 from ..schemes import (
     ResultDict,
@@ -404,7 +403,7 @@ class MongodbProviderExtended(StorageProvider):
                 storage_path=config_path,
                 job_id=result_found["_id"],
             )
-            return None
+            return
 
         # the old config was signed
 
@@ -763,6 +762,7 @@ class MongodbProviderExtended(StorageProvider):
 
         Args:
             display_name: The name of the backend
+            private_jwk: The private JWK to sign the result with
 
         Returns:
             the job dict

--- a/src/sqooler/storage_providers/mongodb.py
+++ b/src/sqooler/storage_providers/mongodb.py
@@ -404,6 +404,7 @@ class MongodbProviderExtended(StorageProvider):
                 storage_path=config_path,
                 job_id=result_found["_id"],
             )
+            return None
 
         # the old config was signed
 
@@ -753,7 +754,7 @@ class MongodbProviderExtended(StorageProvider):
         return file_list
 
     def get_next_job_in_queue(
-        self, display_name: str, private_jwk: Optional[JWK]
+        self, display_name: str, private_jwk: Optional[JWK] = None
     ) -> NextJobSchema:
         """
         A function that obtains the next job in the queue. If there is no job, it returns an empty

--- a/src/sqooler/utils.py
+++ b/src/sqooler/utils.py
@@ -17,7 +17,7 @@ def update_backends(
     storage_provider: StorageProvider, backends: dict[str, Spooler]
 ) -> None:
     """
-    Update the backends on the storage.
+    Update the backends on the storage. Uploads it as a new one if it fails.
 
     Args:
         storage_provider: The storage provider that should be used.
@@ -30,7 +30,14 @@ def update_backends(
         backend_config_dict.display_name = requested_backend
 
         # upload the content through the storage provider
-        storage_provider.upload_config(backend_config_dict, requested_backend)
+        try:
+            storage_provider.update_config(backend_config_dict, requested_backend)
+        except Exception as e:
+            # this should become a log
+            print(
+                f"Failed to update the configuration for {requested_backend}. Uploading it as a new one."
+            )
+            storage_provider.upload_config(backend_config_dict, requested_backend)
 
         # upload the public key if the backend has one and is designed to sign
         if spooler.sign:

--- a/src/sqooler/utils.py
+++ b/src/sqooler/utils.py
@@ -28,22 +28,32 @@ def update_backends(
         backend_config_dict = spooler.get_configuration()
         # set the display name
         backend_config_dict.display_name = requested_backend
-
-        # upload the content through the storage provider
-        try:
-            storage_provider.update_config(backend_config_dict, requested_backend)
-        except Exception as e:
-            # this should become a log
-            print(
-                f"Failed to update the configuration for {requested_backend}. Uploading it as a new one."
-            )
-            storage_provider.upload_config(backend_config_dict, requested_backend)
-
         # upload the public key if the backend has one and is designed to sign
         if spooler.sign:
             private_jwk = spooler.get_private_jwk()
             public_jwk = public_from_private_jwk(private_jwk)
             storage_provider.upload_public_key(public_jwk, requested_backend)
+        else:
+            private_jwk = None
+
+        # upload the content through the storage provider
+        try:
+            storage_provider.update_config(
+                backend_config_dict, requested_backend, private_jwk=private_jwk
+            )
+        except FileNotFoundError:
+            # this should become a log
+            print(
+                f"Failed to update the configuration for {requested_backend}. Uploading it as a new one."
+            )
+            if spooler.sign:
+                storage_provider.upload_config(
+                    backend_config_dict, requested_backend, private_jwk
+                )
+            else:
+                storage_provider.upload_config(
+                    backend_config_dict, requested_backend, private_jwk=None
+                )
 
 
 def main(

--- a/tests/clean_storages.ipynb
+++ b/tests/clean_storages.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Clean dropbox\n",
+    "# Clean dropbox and mongodb\n",
     "\n",
     "We have a lot of tests and sometimes simply forget to clean the dropbox. This is a simple code to clean the dropbox."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,6 +174,73 @@
    "source": [
     "folder_path = \"/Backend_files/Status/\"\n",
     "clean_dummies_from_folder(folder_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mongodb\n",
+    "\n",
+    "For the mongodb we have to do similiar things."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pymongo.mongo_client import MongoClient\n",
+    "from bson.objectid import ObjectId\n",
+    "from bson.errors import InvalidId"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mongodb_username = config(\"MONGODB_USERNAME\")\n",
+    "mongodb_password = config(\"MONGODB_PASSWORD\")\n",
+    "mongodb_database_url = config(\"MONGODB_DATABASE_URL\")\n",
+    "uri = f\"mongodb+srv://{mongodb_username}:{mongodb_password}@{mongodb_database_url}\"\n",
+    "uri = uri + \"/?retryWrites=true&w=majority\"\n",
+    "\n",
+    "# Create a new client and connect to the server\n",
+    "client: MongoClient = MongoClient(uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "database = client[\"backends\"]\n",
+    "collection = database[\"configs\"]\n",
+    "# get all the documents in the collection configs and save the disply_name in a list\n",
+    "\n",
+    "backend_names: list = []\n",
+    "for config_dict in collection.find():\n",
+    "    if \"display_name\" in config_dict:\n",
+    "        if \"dummy\" in config_dict[\"display_name\"]:\n",
+    "            print(\"Deleting config: \" + config_dict[\"display_name\"])\n",
+    "            collection.delete_one({\"_id\": ObjectId(config_dict[\"_id\"])})\n",
+    "    if \"payload\" in config_dict:\n",
+    "        if \"display_name\" in config_dict[\"payload\"]:\n",
+    "            print(config_dict[\"payload\"])\n",
+    "            if \"dummy\" in config_dict[\"payload\"][\"display_name\"]:\n",
+    "                print(\"Deleting config: \" + config_dict[\"payload\"][\"display_name\"])\n",
+    "                collection.delete_one({\"_id\": ObjectId(config_dict[\"_id\"])})\n",
+    "        else:\n",
+    "            print(\"Deleting config: \" + config_dict[\"display_name\"])\n",
+    "            collection.delete_one({\"_id\": ObjectId(config_dict[\"_id\"])})\n",
+    "    else:\n",
+    "        print(\"Deleting random config\")\n",
+    "        collection.delete_one({\"_id\": ObjectId(config_dict[\"_id\"])})\n",
+    "        "
    ]
   }
  ],

--- a/tests/storage_provider_test_utils.py
+++ b/tests/storage_provider_test_utils.py
@@ -181,7 +181,9 @@ class StorageProviderTestUtils:
 
         config_info.cold_atom_type = "boson"
 
-        storage_provider.update_config(config_info, display_name=backend_name)
+        storage_provider.update_config(
+            config_info, display_name=backend_name, private_jwk=private_jwk
+        )
 
         with pytest.raises(FileNotFoundError):
             storage_provider.update_config(config_info, display_name="randonname")
@@ -229,7 +231,7 @@ class StorageProviderTestUtils:
         except TypeError:
             storage_provider = storage_provider_class(self.get_login())
 
-        backend_name, config_info = self.get_dummy_config()
+        backend_name, config_info = self.get_dummy_config(sign=True)
 
         # create a dummy key
         private_jwk, public_jwk = create_jwk_pair(backend_name)
@@ -290,7 +292,7 @@ class StorageProviderTestUtils:
         assert backend_config.last_queue_check is None
 
         # now test that we can move through the queue
-        next_job = storage_provider.get_next_job_in_queue(backend_name)
+        next_job = storage_provider.get_next_job_in_queue(backend_name, private_jwk)
         assert next_job.job_id == job_id
         # now also make sure that we updated the time stamp for the queue
         backend_config = storage_provider.get_config(backend_name)

--- a/tests/storage_provider_test_utils.py
+++ b/tests/storage_provider_test_utils.py
@@ -142,6 +142,44 @@ class StorageProviderTestUtils:
                 self.get_login(), "Whatever%/iswrong"
             )
 
+    def config_tests(self, db_name: str) -> None:
+        """
+        Test that we can create a config and update it.
+
+        Args:
+            db_name: The name of the database.
+        """
+
+        # create a storageprovider object
+        storage_provider_class = self.get_storage_provider()
+        try:
+            storage_provider = storage_provider_class(self.get_login(), db_name)
+        except TypeError:
+            storage_provider = storage_provider_class(self.get_login())
+
+        backend_name, config_info = self.get_dummy_config()
+        storage_provider.upload_config(config_info, display_name=backend_name)
+
+        # now test that we can also get the config
+        obtained_config = storage_provider.get_config(backend_name)
+        assert obtained_config.display_name == backend_name
+
+        with pytest.raises(FileNotFoundError):
+            obtained_config = storage_provider.get_config("random")
+
+        # now test that we can also update the config
+        with pytest.raises(FileExistsError):
+            storage_provider.upload_config(config_info, display_name=backend_name)
+
+        config_info.cold_atom_type = "boson"
+
+        storage_provider.update_config(config_info, display_name=backend_name)
+
+        with pytest.raises(FileNotFoundError):
+            storage_provider.update_config(config_info, display_name="randonname")
+        print("Here we go")
+        print(config_info)
+
     def signature_tests(self, db_name: str) -> None:
         """
         Test that we can create a signature.

--- a/tests/storage_provider_test_utils.py
+++ b/tests/storage_provider_test_utils.py
@@ -148,7 +148,7 @@ class StorageProviderTestUtils:
 
         Args:
             db_name: The name of the database.
-            should I run the tests with signing?
+            sign: should I run the tests with signing?
         """
 
         # create a storageprovider object
@@ -159,7 +159,7 @@ class StorageProviderTestUtils:
             storage_provider = storage_provider_class(self.get_login())
 
         backend_name, config_info = self.get_dummy_config(sign)
-        private_jwk, public_jwk = create_jwk_pair(backend_name)
+        private_jwk, _ = create_jwk_pair(backend_name)
 
         # does it fail if we try to upload the config without a private key?
         if sign:

--- a/tests/storage_provider_test_utils.py
+++ b/tests/storage_provider_test_utils.py
@@ -170,7 +170,9 @@ class StorageProviderTestUtils:
 
         # now test that we can cannot upload the config again
         with pytest.raises(FileExistsError):
-            storage_provider.upload_config(config_info, display_name=backend_name)
+            storage_provider.upload_config(
+                config_info, display_name=backend_name, private_jwk=private_jwk
+            )
 
         # now test that we can also get the config
         obtained_config = storage_provider.get_config(backend_name)

--- a/tests/storage_provider_test_utils.py
+++ b/tests/storage_provider_test_utils.py
@@ -185,10 +185,14 @@ class StorageProviderTestUtils:
             config_info, display_name=backend_name, private_jwk=private_jwk
         )
 
+        # test that we cannot update the config with a wrong private key
+        wrong_private_jwk, _ = create_jwk_pair(backend_name)
+        with pytest.raises(ValueError):
+            storage_provider.update_config(
+                config_info, display_name=backend_name, private_jwk=wrong_private_jwk
+            )
         with pytest.raises(FileNotFoundError):
             storage_provider.update_config(config_info, display_name="randonname")
-        print("Here we go")
-        print(config_info)
 
     def signature_tests(self, db_name: str) -> None:
         """

--- a/tests/test_dropbox_provider.py
+++ b/tests/test_dropbox_provider.py
@@ -16,6 +16,9 @@ from sqooler.schemes import ResultDict, DropboxLoginInformation
 from .storage_provider_test_utils import StorageProviderTestUtils
 
 
+DB_NAME = "dropboxtest"
+
+
 class TestDropboxProvider(StorageProviderTestUtils):
     """
     The class that contains all the tests for the dropbox provider.
@@ -78,24 +81,12 @@ class TestDropboxProvider(StorageProviderTestUtils):
         # clean up our mess
         storage_provider.delete_file(second_path, file_id)
 
-    def test_upload_configs(self) -> None:
+    def test_upload_and_update_config(self) -> None:
         """
-        We would like to make sure that we can properly upload the configuration files
-        that come from the spoolers.
+        Test that we can upload and update a config.
         """
-        storage_provider = DropboxProvider(self.get_login())
-
-        backend_name, config_info = self.get_dummy_config(sign=False)
-        storage_provider.upload_config(config_info, backend_name)
-
-        # can we get the backend in the list ?
-        dummy_path = f"Backend_files/Config/{backend_name}"
-        backend_dict = storage_provider.get_file_content(dummy_path, "config")
-        assert backend_dict["display_name"] == config_info.display_name
-
-        storage_provider.delete_file(dummy_path, "config")
-        # delete also the old folder
-        storage_provider.delete_folder(dummy_path)
+        self.config_tests(DB_NAME)
+        self.config_tests(DB_NAME, sign=False)
 
     def test_get_next_job_in_queue(self) -> None:
         """

--- a/tests/test_dropbox_provider.py
+++ b/tests/test_dropbox_provider.py
@@ -13,8 +13,10 @@ from decouple import config
 from sqooler.storage_providers.dropbox import DropboxProvider
 from sqooler.schemes import ResultDict, DropboxLoginInformation
 
-from .storage_provider_test_utils import StorageProviderTestUtils
-
+from .storage_provider_test_utils import (
+    StorageProviderTestUtils,
+    clean_dummies_from_folder,
+)
 
 DB_NAME = "dropboxtest"
 
@@ -52,6 +54,15 @@ class TestDropboxProvider(StorageProviderTestUtils):
             "refresh_token": refresh_token,
         }
         return DropboxLoginInformation(**login_dict)
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        """
+        Clean out the old dummy files
+        """
+        # clean stupid dummy files for the config
+        backend_config_path = "/Backend_files/Config/"
+        clean_dummies_from_folder(backend_config_path)
 
     def test_upload_etc(self) -> None:
         """

--- a/tests/test_dropbox_provider_extended.py
+++ b/tests/test_dropbox_provider_extended.py
@@ -11,7 +11,10 @@ import pytest
 from sqooler.storage_providers.dropbox import DropboxProviderExtended
 from sqooler.schemes import DropboxLoginInformation
 
-from .storage_provider_test_utils import StorageProviderTestUtils
+from .storage_provider_test_utils import (
+    StorageProviderTestUtils,
+    clean_dummies_from_folder,
+)
 
 DB_NAME = "dropboxtest"
 
@@ -49,6 +52,15 @@ class TestDropboxProviderExtended(StorageProviderTestUtils):
             "refresh_token": refresh_token,
         }
         return DropboxLoginInformation(**login_dict)
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        """
+        Clean out the old dummy files
+        """
+        # clean stupid dummy files for the config
+        backend_config_path = "/Backend_files/Config/"
+        clean_dummies_from_folder(backend_config_path)
 
     def test_dropbox_object(self) -> None:
         """

--- a/tests/test_dropbox_provider_extended.py
+++ b/tests/test_dropbox_provider_extended.py
@@ -131,6 +131,13 @@ class TestDropboxProviderExtended(StorageProviderTestUtils):
         # clean up our mess
         storage_provider.delete_file(storage_path, job_id)
 
+    def test_upload_and_update_config(self) -> None:
+        """
+        Test that we can upload and update a config.
+        """
+        self.config_tests(DB_NAME)
+        self.config_tests(DB_NAME, sign=False)
+
     def test_configs(self) -> None:
         """
         Test that we are able to obtain a list of backends.
@@ -139,7 +146,7 @@ class TestDropboxProviderExtended(StorageProviderTestUtils):
         # create a dropbox object
         storage_provider = DropboxProviderExtended(self.get_login(), DB_NAME)
 
-        backend_name, config_info = self.get_dummy_config()
+        backend_name, config_info = self.get_dummy_config(sign=False)
         storage_provider.upload_config(config_info, backend_name)
         dummy_path = f"Backend_files/Config/{backend_name}"
 

--- a/tests/test_local_provider.py
+++ b/tests/test_local_provider.py
@@ -86,36 +86,12 @@ class TestLocalProvider(StorageProviderTestUtils):
         # clean up our mess
         storage_provider.delete_file(second_path, job_id)
 
-    def test_upload_configs(self) -> None:
+    def test_upload_and_update_config(self) -> None:
         """
-        We would like to make sure that we can properly upload the configuration files
-        that come from the spoolers.
+        Test that we can upload and update a config.
         """
-
-        storage_provider = LocalProvider(self.get_login())
-
-        backend_name, backend_info = self.get_dummy_config()
-        storage_provider.upload_config(backend_info, backend_name)
-
-        # can we get the backend in the list ?
-        # get the database on which we work
-        uploaded_path = storage_provider.base_path + "/backends/configs"
-        full_json_path = uploaded_path + "/" + backend_name + ".json"
-        with open(full_json_path, "r", encoding="UTF-8") as json_file:
-            result_found = json.load(json_file)
-
-        if result_found is None:
-            raise ValueError("The backend was not uploaded properly.")
-        assert result_found["display_name"] == backend_info.display_name
-
-        # make sure that the upload of the same backend does only update it.
-        backend_info.num_wires = 4
-        storage_provider.upload_config(backend_info, backend_name)
-        with open(full_json_path, "r", encoding="UTF-8") as json_file:
-            result_found = json.load(json_file)
-
-        # clean up our mess and remove the file
-        storage_provider.delete_file("backends/configs", backend_name)
+        self.config_tests(DB_NAME)
+        self.config_tests(DB_NAME, sign=False)
 
     def test_get_next_job_in_queue(self) -> None:
         """
@@ -125,7 +101,7 @@ class TestLocalProvider(StorageProviderTestUtils):
         private_jwk, _ = create_jwk_pair("test")
         # create a dummy config
         backend_name, backend_info = self.get_dummy_config()
-        storage_provider.upload_config(backend_info, backend_name)
+        storage_provider.upload_config(backend_info, backend_name, private_jwk)
 
         queue_path = "jobs/queued/" + backend_name
 
@@ -146,7 +122,7 @@ class TestLocalProvider(StorageProviderTestUtils):
         assert job_list
 
         # the last step is to get the next job and see if this nicely worked out
-        next_job = storage_provider.get_next_job_in_queue(backend_name)
+        next_job = storage_provider.get_next_job_in_queue(backend_name, private_jwk)
 
         assert next_job.job_id == job_id
 

--- a/tests/test_local_provider.py
+++ b/tests/test_local_provider.py
@@ -3,7 +3,6 @@ The tests for the storage provider using mongodb
 """
 
 import uuid
-import json
 import shutil
 from typing import Any
 

--- a/tests/test_local_provider_extended.py
+++ b/tests/test_local_provider_extended.py
@@ -164,6 +164,12 @@ class TestLocalProviderExtended(StorageProviderTestUtils):
             storage_provider.get_backend_dict("dummy_non_existing")
         storage_provider.delete_file(config_path, backend_name)
 
+    def test_upload_and_update_config(self) -> None:
+        """
+        Test that we can upload and update a config.
+        """
+        self.config_tests(DB_NAME)
+
     def test_status(self) -> None:
         """
         Test that we are able to obtain the status of the backend.

--- a/tests/test_local_provider_extended.py
+++ b/tests/test_local_provider_extended.py
@@ -169,6 +169,7 @@ class TestLocalProviderExtended(StorageProviderTestUtils):
         Test that we can upload and update a config.
         """
         self.config_tests(DB_NAME)
+        self.config_tests(DB_NAME, sign=False)
 
     def test_status(self) -> None:
         """

--- a/tests/test_mongodb_provider.py
+++ b/tests/test_mongodb_provider.py
@@ -8,11 +8,12 @@ from typing import Any
 # get the environment variables
 from decouple import config
 
+from bson.objectid import ObjectId
+
 from sqooler.storage_providers.mongodb import MongodbProvider
 from sqooler.schemes import ResultDict, MongodbLoginInformation
 
 from .storage_provider_test_utils import StorageProviderTestUtils
-from bson.objectid import ObjectId
 
 DB_NAME = "mongodbtest"
 

--- a/tests/test_mongodb_provider.py
+++ b/tests/test_mongodb_provider.py
@@ -12,6 +12,7 @@ from sqooler.storage_providers.mongodb import MongodbProvider
 from sqooler.schemes import ResultDict, MongodbLoginInformation
 
 from .storage_provider_test_utils import StorageProviderTestUtils
+from bson.objectid import ObjectId
 
 DB_NAME = "mongodbtest"
 
@@ -88,6 +89,31 @@ class TestMongodbProvider(StorageProviderTestUtils):
             if collection_name.startswith("dummy"):
                 collection = database[collection_name]
                 collection.drop()
+
+        # Remove all the dummy configs
+        database = storage_provider.client["backends"]
+        collection = database["configs"]
+
+        database = storage_provider.client["status"]
+        for config_dict in collection.find():
+            if "display_name" in config_dict:
+                if "dummy" in config_dict["display_name"]:
+                    print("Deleting config: " + config_dict["display_name"])
+                    collection.delete_one({"_id": ObjectId(config_dict["_id"])})
+            if "payload" in config_dict:
+                if "display_name" in config_dict["payload"]:
+                    print(config_dict["payload"])
+                    if "dummy" in config_dict["payload"]["display_name"]:
+                        print(
+                            "Deleting config: " + config_dict["payload"]["display_name"]
+                        )
+                        collection.delete_one({"_id": ObjectId(config_dict["_id"])})
+                else:
+                    print("Deleting config: " + config_dict["display_name"])
+                    collection.delete_one({"_id": ObjectId(config_dict["_id"])})
+            else:
+                print("Deleting random config")
+                collection.delete_one({"_id": ObjectId(config_dict["_id"])})
 
     def test_config_upload(self) -> None:
         """

--- a/tests/test_mongodb_provider.py
+++ b/tests/test_mongodb_provider.py
@@ -90,6 +90,9 @@ class TestMongodbProvider(StorageProviderTestUtils):
                 collection.drop()
 
     def test_config_upload(self) -> None:
+        """
+        Test that we can upload a config and modify it properly.
+        """
         self.config_tests(DB_NAME)
         self.config_tests(DB_NAME, sign=False)
 
@@ -142,7 +145,7 @@ class TestMongodbProvider(StorageProviderTestUtils):
         # get the backend and test that it was uploaded properly
         config_dict = storage_provider.get_config(backend_name)
         print(config_dict)
-        assert config_dict.sign == False
+        assert config_dict.sign is False
         # first we have to upload a dummy job
         job_id = (uuid.uuid4().hex)[:24]
         job_dict = {"job_id": job_id, "job_json_path": "None"}

--- a/tests/test_mongodb_provider.py
+++ b/tests/test_mongodb_provider.py
@@ -13,6 +13,8 @@ from sqooler.schemes import ResultDict, MongodbLoginInformation
 
 from .storage_provider_test_utils import StorageProviderTestUtils
 
+DB_NAME = "mongodbtest"
+
 
 class TestMongodbProvider(StorageProviderTestUtils):
     """
@@ -87,6 +89,10 @@ class TestMongodbProvider(StorageProviderTestUtils):
                 collection = database[collection_name]
                 collection.drop()
 
+    def test_config_upload(self) -> None:
+        self.config_tests(DB_NAME)
+        self.config_tests(DB_NAME, sign=False)
+
     def test_upload_etc(self) -> None:
         """
         Test that it is possible to upload a file.
@@ -123,37 +129,6 @@ class TestMongodbProvider(StorageProviderTestUtils):
         # clean up our mess
         storage_provider.delete_file(second_path, job_id)
 
-    def test_upload_configs(self) -> None:
-        """
-        We would like to make sure that we can properly upload the configuration files
-        that come from the spoolers.
-        """
-
-        storage_provider = MongodbProvider(self.get_login())
-
-        backend_name, backend_config_info = self.get_dummy_config(sign=False)
-        storage_provider.upload_config(backend_config_info, backend_name)
-
-        # can we get the backend in the list ?
-        # get the database on which we work
-        database = storage_provider.client["backends"]
-        configs = database["configs"]
-        document_to_find = {"display_name": backend_name}
-
-        result_found = configs.find_one(document_to_find)
-        if result_found is None:
-            raise ValueError("The backend was not uploaded properly.")
-        assert result_found["display_name"] == backend_config_info.display_name
-
-        # make sure that the upload of the same backend does only update it.
-        backend_config_info.num_wires = 4
-        storage_provider.upload_config(backend_config_info, backend_name)
-        results_found = configs.find(document_to_find)
-        assert len(list(results_found)) == 1
-
-        # clean up our mess
-        configs.delete_one(document_to_find)
-
     def test_get_next_job_in_queue(self) -> None:
         """
         Is it possible to work through the queue of jobs?
@@ -164,6 +139,10 @@ class TestMongodbProvider(StorageProviderTestUtils):
         backend_name, backend_info = self.get_dummy_config(sign=False)
         storage_provider.upload_config(backend_info, backend_name)
 
+        # get the backend and test that it was uploaded properly
+        config_dict = storage_provider.get_config(backend_name)
+        print(config_dict)
+        assert config_dict.sign == False
         # first we have to upload a dummy job
         job_id = (uuid.uuid4().hex)[:24]
         job_dict = {"job_id": job_id, "job_json_path": "None"}

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -157,13 +157,19 @@ class TestMongodbProviderExtended(StorageProviderTestUtils):
         # clean up our mess
         storage_provider.delete_file(second_path, job_id)
 
+    def test_upload_and_update_config(self) -> None:
+        """
+        Test that we can upload and update a config.
+        """
+        self.config_tests(DB_NAME)
+
     def test_configs(self) -> None:
         """
         Test that we are able to obtain a list of backends.
         """
         # create a mongodb object
         storage_provider = MongodbProviderExtended(self.get_login(), DB_NAME)
-        backend_name, backend_config_info = self.get_dummy_config()
+        backend_name, backend_config_info = self.get_dummy_config(sign=False)
         config_path = "backends/configs"
 
         storage_provider.upload_config(backend_config_info, backend_name)

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -330,10 +330,9 @@ class TestMongodbProviderExtended(StorageProviderTestUtils):
 
         # remove the obsolete config from the storage
         config_path = "backends/configs"
-        document_to_find = {"display_name": backend_name}
 
         database = storage_provider.client["backends"]
         collection = database["configs"]
-
+        document_to_find = {"payload.display_name": backend_name}
         result_found = collection.find_one(document_to_find)
         storage_provider.delete_file(config_path, str(result_found["_id"]))

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -162,6 +162,7 @@ class TestMongodbProviderExtended(StorageProviderTestUtils):
         Test that we can upload and update a config.
         """
         self.config_tests(DB_NAME)
+        self.config_tests(DB_NAME, sign=False)
 
     def test_configs(self) -> None:
         """

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -12,6 +12,8 @@ from sqooler.schemes import MongodbLoginInformation, BackendConfigSchemaIn
 
 from .storage_provider_test_utils import StorageProviderTestUtils
 
+from bson.objectid import ObjectId
+
 DB_NAME = "mongodbtest"
 
 
@@ -87,6 +89,31 @@ class TestMongodbProviderExtended(StorageProviderTestUtils):
             if collection_name.startswith("dummy"):
                 collection = database[collection_name]
                 collection.drop()
+
+        # Remove all the dummy configs
+        database = storage_provider.client["backends"]
+        collection = database["configs"]
+
+        database = storage_provider.client["status"]
+        for config_dict in collection.find():
+            if "display_name" in config_dict:
+                if "dummy" in config_dict["display_name"]:
+                    print("Deleting config: " + config_dict["display_name"])
+                    collection.delete_one({"_id": ObjectId(config_dict["_id"])})
+            if "payload" in config_dict:
+                if "display_name" in config_dict["payload"]:
+                    print(config_dict["payload"])
+                    if "dummy" in config_dict["payload"]["display_name"]:
+                        print(
+                            "Deleting config: " + config_dict["payload"]["display_name"]
+                        )
+                        collection.delete_one({"_id": ObjectId(config_dict["_id"])})
+                else:
+                    print("Deleting config: " + config_dict["display_name"])
+                    collection.delete_one({"_id": ObjectId(config_dict["_id"])})
+            else:
+                print("Deleting random config")
+                collection.delete_one({"_id": ObjectId(config_dict["_id"])})
 
     def test_mongodb_object(self) -> None:
         """

--- a/tests/test_mongodb_provider_extended.py
+++ b/tests/test_mongodb_provider_extended.py
@@ -7,12 +7,13 @@ from typing import Any
 from decouple import config
 
 import pytest
+from bson.objectid import ObjectId
+
 from sqooler.storage_providers.mongodb import MongodbProviderExtended
 from sqooler.schemes import MongodbLoginInformation, BackendConfigSchemaIn
 
 from .storage_provider_test_utils import StorageProviderTestUtils
 
-from bson.objectid import ObjectId
 
 DB_NAME = "mongodbtest"
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -6,6 +6,8 @@ import base64
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.exceptions import InvalidSignature
 
+from datetime import datetime, timezone
+
 import pytest
 
 from sqooler.security import (
@@ -105,6 +107,11 @@ def test_sign_and_verify_jws() -> None:
     signed_pl.payload = {"test": "test1"}
 
     assert not signed_pl.verify_signature(public_jwk)
+
+    # test if we can sign a payload with a datetime
+    current_time = datetime.now(timezone.utc)
+    payload_dt = {"test": "test", "last_queued": current_time}
+    signed_pl_dt = sign_payload(payload_dt, private_jwk)
 
 
 def test_jws_serialization() -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,10 +3,11 @@ In this module we test the basic ability to sign payloads and verify the signatu
 """
 
 import base64
+from datetime import datetime, timezone
+
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.exceptions import InvalidSignature
 
-from datetime import datetime, timezone
 
 import pytest
 
@@ -111,7 +112,7 @@ def test_sign_and_verify_jws() -> None:
     # test if we can sign a payload with a datetime
     current_time = datetime.now(timezone.utc)
     payload_dt = {"test": "test", "last_queued": current_time}
-    signed_pl_dt = sign_payload(payload_dt, private_jwk)
+    sign_payload(payload_dt, private_jwk)
 
 
 def test_jws_serialization() -> None:

--- a/tests/test_spoolers.py
+++ b/tests/test_spoolers.py
@@ -199,7 +199,7 @@ def test_spooler_jwk() -> None:
         ins_schema_dict={}, device_config=DummyExperiment, n_wires=2, sign=True
     )
 
-    private_jwk = test_spooler.get_private_jwk()
+    test_spooler.get_private_jwk()
 
 
 def test_spooler_cold_atom() -> None:

--- a/tests/test_spoolers.py
+++ b/tests/test_spoolers.py
@@ -191,6 +191,17 @@ def test_spooler_config() -> None:
     assert spooler_config.operational
 
 
+def test_spooler_jwk() -> None:
+    """
+    Test that we can easily get the private jwk.
+    """
+    test_spooler = Spooler(
+        ins_schema_dict={}, device_config=DummyExperiment, n_wires=2, sign=True
+    )
+
+    private_jwk = test_spooler.get_private_jwk()
+
+
 def test_spooler_cold_atom() -> None:
     """
     Test that we cannot set the spooler with the wrong cold atom type.


### PR DESCRIPTION
- We are now able to sign the config dicts.
- This avoids us to accidentally overwrite other dicts with the same name.

This is implemented by:

- We are now clearly separating the case of an `upload` and an `update`.
- `update` for a signed backend is only possible if you are the owner of the private key.

